### PR TITLE
any for browserprovider

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -78,7 +78,7 @@ export class DelphinusBrowserConnector extends DelphinusProvider<BrowserProvider
       throw "MetaMask not installed, Browser mode is not available.";
     }
     // https://eips.ethereum.org/EIPS/eip-1193#summary
-    super(new BrowserProvider(window.ethereum));
+    super(new BrowserProvider(window.ethereum, "any"));
   }
 
   async connect() {


### PR DESCRIPTION
https://github.com/Uniswap/web3-react/issues/127

Use `any` as the expected network, otherwise ethers will throw an error for a network switch